### PR TITLE
Add local image support for notes and refactor image handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-firestore")
     implementation("com.google.firebase:firebase-auth")
+    implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.android.gms:play-services-auth:21.0.0")
     implementation("com.google.firebase:firebase-storage-ktx")
     // --- View System Dependencies (Retained based on your original file) ---

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <!--   API 33+  -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!--   API ≤28  (opsional) -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
 
     <queries>
@@ -35,14 +40,16 @@
             </intent-filter>
         </activity>
         <provider
-            android:authorities="${applicationId}.fileprovider"
             android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+
 
     </application>
 

--- a/app/src/main/java/com/example/sealnote/MainActivity.kt
+++ b/app/src/main/java/com/example/sealnote/MainActivity.kt
@@ -8,33 +8,40 @@ import androidx.compose.runtime.getValue
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.example.sealnote.data.UserPreferencesRepository // Import UserPreferencesRepository
-import com.example.sealnote.data.ThemeOption // Pastikan ThemeOption diimpor
+import com.example.sealnote.data.UserPreferencesRepository
+import com.example.sealnote.data.ThemeOption
 import com.example.sealnote.ui.theme.SealnoteTheme
 import com.example.sealnote.view.AppNavigation
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject // <--- PASTIKAN INI DIIMPOR
+import com.google.firebase.auth.FirebaseAuth
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : FragmentActivity() {
 
-    // INJEKSI UserPreferencesRepository langsung di sini
     @Inject
-    lateinit var userPreferencesRepository: UserPreferencesRepository // <--- PERBAIKAN DI SINI
+    lateinit var firebaseAuth: FirebaseAuth // Inject FirebaseAuth untuk memeriksa status login
+
+    @Inject
+    lateinit var userPreferencesRepository: UserPreferencesRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // enableEdgeToEdge() // uncomment jika Anda ingin tampilan edge-to-edge
+
+        // Tentukan startDestination secara dinamis
+        val startDestination = if (firebaseAuth.currentUser != null) {
+            "homepage" // Jika sudah login, langsung ke homepage
+        } else {
+            "stealthCalculator"    // Jika belum login, ke halaman login
+        }
 
         setContent {
-            // Gunakan instance yang sudah diinjeksi
             val themeOption by userPreferencesRepository.themeOption.collectAsStateWithLifecycle(
-                initialValue = ThemeOption.SYSTEM // Berikan nilai awal yang valid
-                // lifecycleOwner dan minActiveState sudah memiliki default yang baik
+                initialValue = ThemeOption.SYSTEM
             )
 
             SealnoteTheme(themeOption = themeOption) {
-                AppNavigation()
+                AppNavigation(startDestination = startDestination) // Teruskan startDestination
             }
         }
     }

--- a/app/src/main/java/com/example/sealnote/data/NotesRepository.kt
+++ b/app/src/main/java/com/example/sealnote/data/NotesRepository.kt
@@ -90,15 +90,16 @@ class NotesRepository @Inject constructor(
         if (noteId == null) {
             val newNoteDocument = collection.document()
             val newNote = Notes(
-                id = newNoteDocument.id,
-                userId = userId,
-                title = title,
-                content = content,
-                createdAt = currentTime,
-                updatedAt = currentTime,
-                bookmarked = false,
-                secret = isSecret,
-                trashed = false
+                id          = newNoteDocument.id,
+                userId      = userId,
+                title       = title,
+                content     = content,
+                createdAt   = currentTime,
+                updatedAt   = currentTime,
+                bookmarked  = false,
+                secret      = isSecret,
+                trashed     = false,
+                imageUrl    = imageUrl          // <-- ada
             )
             newNoteDocument.set(newNote).await()
         } else {
@@ -107,7 +108,8 @@ class NotesRepository @Inject constructor(
                     "title" to title,
                     "content" to content,
                     "secret" to isSecret,
-                    "updatedAt" to currentTime
+                    "updatedAt" to currentTime,
+                    "imageUrl"  to imageUrl
                 )
             ).await()
         }

--- a/app/src/main/java/com/example/sealnote/di/FirebaseModule.kt
+++ b/app/src/main/java/com/example/sealnote/di/FirebaseModule.kt
@@ -38,11 +38,11 @@ object FirebaseModule {
         return Firebase.firestore
     }
 
-    @Provides
-    @Singleton
-    fun provideFirebaseStorage(): FirebaseStorage { // <--- SEDIAKAN FirebaseStorage
-        return Firebase.storage
-    }
+//    @Provides
+//    @Singleton
+//    fun provideFirebaseStorage(): FirebaseStorage { // <--- SEDIAKAN FirebaseStorage
+//        return Firebase.storage
+//    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/sealnote/di/ImageSaver.kt
+++ b/app/src/main/java/com/example/sealnote/di/ImageSaver.kt
@@ -1,0 +1,41 @@
+package com.example.sealnote.di
+
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import java.io.File
+import java.io.FileInputStream
+import java.io.OutputStream
+object ImageSaver {
+    fun copyTempToGallery(context: Context, tempFile: File): Uri? {
+        val resolver = context.contentResolver
+
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, tempFile.name)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/SealNote")
+            if (Build.VERSION.SDK_INT >= 29) put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+
+        val galleryUri = resolver.insert(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values
+        ) ?: return null
+
+        resolver.openOutputStream(galleryUri).use { outStream ->
+            FileInputStream(tempFile).use { inStream ->
+                inStream.copyTo(outStream as OutputStream)
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= 29) {
+            values.clear()
+            values.put(MediaStore.Images.Media.IS_PENDING, 0)
+            resolver.update(galleryUri, values, null, null)
+        }
+
+        return galleryUri
+    }
+}

--- a/app/src/main/java/com/example/sealnote/di/MediaStoreHelper.kt
+++ b/app/src/main/java/com/example/sealnote/di/MediaStoreHelper.kt
@@ -1,0 +1,31 @@
+package com.example.sealnote.di
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+
+object MediaStoreHelper {
+
+    /** Buat entry baru **dengan IS_PENDING = 1**  */
+    fun createImageUri(context: Context): Uri? {
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, "IMG_${System.currentTimeMillis()}.jpg")
+            put(MediaStore.Images.Media.MIME_TYPE,  "image/jpeg")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/SealNote")
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+        return context.contentResolver.insert(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            values
+        )
+    }
+
+    /** Panggil setelah foto BERHASIL di‑capture */
+    fun publishImage(context: Context, uri: Uri) {
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.IS_PENDING, 0)
+        }
+        context.contentResolver.update(uri, values, null, null)
+    }
+}

--- a/app/src/main/java/com/example/sealnote/model/Notes.kt
+++ b/app/src/main/java/com/example/sealnote/model/Notes.kt
@@ -25,6 +25,7 @@ data class Notes(
     @ServerTimestamp
     val createdAt: Date? = null,
     val imageUrl: String? = null, // <--- TAMBAHKAN BARIS INI
+    val localImageUri: String? = null,
     @ServerTimestamp
     val updatedAt: Date? = null,
 

--- a/app/src/main/java/com/example/sealnote/view/AppNavigation.kt
+++ b/app/src/main/java/com/example/sealnote/view/AppNavigation.kt
@@ -1,3 +1,5 @@
+// path: app/src/main/java/com/example/sealnote/view/AppNavigation.kt
+
 package com.example.sealnote.view
 
 import androidx.compose.runtime.Composable
@@ -20,13 +22,13 @@ import com.example.sealnote.viewmodel.StealthScientificViewModel
 fun AppNavigation(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
-    startDestination: String = "stealthCalculator"
+    startDestination: String // Terima startDestination dari parameter
 ) {
     val calculatorHistoryViewModel: CalculatorHistoryViewModel = hiltViewModel()
 
     NavHost(
         navController = navController,
-        startDestination = startDestination,
+        startDestination = startDestination, // Gunakan startDestination dari parameter
         modifier = modifier
     ) {
         // --- Stealth Mode ---

--- a/app/src/main/java/com/example/sealnote/view/StealthCalculatorScreen.kt
+++ b/app/src/main/java/com/example/sealnote/view/StealthCalculatorScreen.kt
@@ -74,7 +74,12 @@ fun StealthCalculatorScreen(
                     onClick = {
                         scope.launch { drawerState.close() }
                     },
-                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                    colors = NavigationDrawerItemDefaults.colors( // Menyesuaikan warna drawer item
+                        selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        selectedTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        selectedIconColor = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
                 )
                 NavigationDrawerItem(
                     label = { Text("Kalkulator Ilmiah") },
@@ -85,7 +90,12 @@ fun StealthCalculatorScreen(
                             popUpTo("stealthCalculator") { inclusive = true }
                         }
                     },
-                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                    colors = NavigationDrawerItemDefaults.colors( // Menyesuaikan warna drawer item
+                        unselectedContainerColor = Color.Transparent,
+                        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 )
                 NavigationDrawerItem(
                     label = { Text("Riwayat Kalkulasi") },
@@ -94,30 +104,39 @@ fun StealthCalculatorScreen(
                         scope.launch { drawerState.close() }
                         navController.navigate("stealthHistory")
                     },
-                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                    colors = NavigationDrawerItemDefaults.colors( // Menyesuaikan warna drawer item
+                    unselectedContainerColor = Color.Transparent,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
                 )
             }
         },
         gesturesEnabled = drawerState.isOpen
     ) {
         Scaffold(
+            containerColor = MaterialTheme.colorScheme.background,
             topBar = {
-                TopAppBar(
+                CenterAlignedTopAppBar(
                     title = {
                         Text(
                             text = "Kalkulator",
                             modifier = Modifier.fillMaxWidth(),
-                            textAlign = TextAlign.Center
+                            textAlign = TextAlign.Center,
+                            style = MaterialTheme.typography.headlineSmall, // Menggunakan tipografi tema
+                            color = MaterialTheme.colorScheme.onSurface
                         )
                     },
                     navigationIcon = {
                         IconButton(onClick = { scope.launch { drawerState.open() } }) {
-                            Icon(Icons.Filled.Menu, contentDescription = "Menu")
+                            Icon(Icons.Filled.Menu, contentDescription = "Menu", tint = MaterialTheme.colorScheme.onSurface)
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = CalcScreenBackground,
-                        titleContentColor = CalcDisplayTextColor
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurface
                     )
                 )
             }
@@ -125,7 +144,7 @@ fun StealthCalculatorScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(CalcScreenBackground)
+                    .background(MaterialTheme.colorScheme.background)
                     .padding(paddingValues)
             ) {
                 CalculatorDisplay(
@@ -159,7 +178,7 @@ private fun CalculatorDisplay(displayText: String, modifier: Modifier = Modifier
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = CalcDisplayCardBackground),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Box(
@@ -168,9 +187,8 @@ private fun CalculatorDisplay(displayText: String, modifier: Modifier = Modifier
         ) {
             Text(
                 text = displayText,
-                color = CalcDisplayTextColor,
-                fontSize = 56.sp,
-                fontWeight = FontWeight.Normal,
+                color = MaterialTheme.colorScheme.onSurface, // Menggunakan warna tema
+                style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Normal),
                 textAlign = TextAlign.End,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
@@ -261,7 +279,7 @@ private fun CalculatorButtonModified(
             backgroundColor = null; backgroundBrush = CalcOperatorGradient
         }
         else -> {
-            backgroundColor = CalcNonOperatorButtonBg; backgroundBrush = null
+            backgroundColor = MaterialTheme.colorScheme.surfaceContainerHigh; backgroundBrush = null
         }
     }
 
@@ -284,21 +302,22 @@ private fun CalculatorButtonModified(
             Icon(
                 imageVector = info.icon,
                 contentDescription = info.description,
-                tint = CalcButtonIconColor,
+                tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.size(28.dp)
             )
         } else {
             Text(
                 text = info.symbol,
-                color = CalcButtonTextColor,
-                fontSize = info.textSize,
-                fontWeight = FontWeight.Medium
-            )
+                color = MaterialTheme.colorScheme.onSurface, // Menggunakan warna tema
+                style = MaterialTheme.typography.bodyLarge.copy( // Menggunakan tipografi tema
+                    fontSize = info.textSize,
+                    fontWeight = if (info.type == ButtonType.OPERATOR || info.type == ButtonType.FUNCTION) FontWeight.Normal else FontWeight.Medium
+            ))
         }
     }
 }
 
-@Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true)
 @Composable
 fun CalculatorScreenModifiedPreview() {
     MaterialTheme {

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-files-path name="my_images" path="Pictures" />
+    <external-files-path name="images" path="Pictures/" />
 </paths>


### PR DESCRIPTION
Introduces local image URI support for notes, allowing images to be saved and referenced locally instead of uploading to Firebase Storage. Adds ImageSaver and MediaStoreHelper utilities for managing images in the device gallery. Updates permissions in the manifest for image access, refactors AddNotesScreen and AddEditNoteViewModel to use local URIs, and adjusts navigation to support dynamic start destinations based on authentication state. Also includes UI improvements for calculator screens and minor code cleanups.